### PR TITLE
Add docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM rust:1.67.0-slim-bullseye as builder
+
+WORKDIR /app/portal
+
+COPY . .
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl make libssl-dev pkg-config libudev-dev && \
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    cd dashboard && \
+    npm install && \
+    npm run build && \
+    cd /app/portal && \
+    cargo install --path . 
+
+
+FROM debian:bullseye-slim
+
+ARG USERNAME=mirrorx
+ARG USER_UID=1000
+ARG USER_GID=$USER_UID
+
+RUN groupadd --gid $USER_GID $USERNAME && \
+    useradd --uid $USER_UID --gid $USER_GID -m $USERNAME && \
+    mkdir -p /app/portal && \
+    chown $USER_UID:$USER_GID /app/portal
+
+WORKDIR /app/portal
+
+USER $USERNAME
+
+COPY --from=builder /usr/local/cargo/bin/portal .
+COPY .env .
+
+CMD ["./portal"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,39 @@
+version: '3'
+
+# networks:
+#   mirrorx-net:
+#     external: false
+
+services:
+  portal:
+    container_name: mirrorx-portal
+    # ports:
+    #   - 6500:6500
+    #   - 28000:28000
+    #   - 28001:28001
+    image: mirrorx-portal:latest
+    build:
+      context: .
+      dockerfile: Dockerfile
+    # volumes:
+    #   - ./env:/app/portal/.env
+    # networks:
+    #   - mirrorx-net
+    network_mode: host
+    restart: unless-stopped
+
+  relay:
+    container_name: mirrorx-relay
+    # ports:
+    #   - 6501:6501
+    #   - 38000:38000
+    image: mirrorx-relay:latest
+    build:
+      context: ../relay/
+      dockerfile: ../relay/Dockerfile
+    network_mode: host
+    # volumes:
+    #   - ./env:/app/relay/.env
+    # networks:
+    #   - mirrorx-net
+    restart: unless-stopped


### PR DESCRIPTION
增加 Dockerfile和 dockercompose.yaml，方便编译自建服务端

目前是需要自行clone项目构建镜像，后续可以推送到 dockerhub，更方便拉取
使用命令
```sh
## relay 需要在放在 portal 同一级目录
git clone https://github.com/MirrorX-Desktop/relay.git
cd portal
docker compose build
docker compose up -d
##旧版 docker:
docker-compose build
docker-compose up -d
```